### PR TITLE
Optional alphabetization of output keys, with cleanups

### DIFF
--- a/.github/actions/localize-push-pull/Dockerfile
+++ b/.github/actions/localize-push-pull/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:2
 COPY entrypoint.sh /entrypoint.sh
+RUN curl -L -o /usr/bin/jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64 && chmod +x /usr/bin/jq
 RUN pip install --ignore-installed localize==1.0.9
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/localize-push-pull/action.yml
+++ b/.github/actions/localize-push-pull/action.yml
@@ -35,6 +35,10 @@ inputs:
     description: "If true will restructure files to match the structure expected by i18next. EG `language_code/translations.json`"
     required: false
     default: "false"
+  alphabetize-keys:
+    description: "If true, recursively alphabetize keys of generated output. This helps reduce diff churn."
+    required: false
+    default: "false"
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -48,3 +52,4 @@ runs:
     - ${{ inputs.input-path }}
     - ${{ inputs.output-path }}
     - ${{ inputs.restructure-files }}
+    - ${{ inputs.alphabetize-keys }}

--- a/.github/actions/localize-push-pull/action.yml
+++ b/.github/actions/localize-push-pull/action.yml
@@ -34,7 +34,7 @@ inputs:
   restructure-files:
     description: "If true will restructure files to match the structure expected by i18next. EG `language_code/translations.json`"
     required: false
-    default: false
+    default: "false"
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/.github/actions/localize-push-pull/entrypoint.sh
+++ b/.github/actions/localize-push-pull/entrypoint.sh
@@ -9,11 +9,12 @@ LANGUAGES=$6
 INPUTPATH=$7
 OUTPUTPATH=$8 # this should be a temp location.
 RESTRUCTURE=$9
+ALPHABETIZE=$10
 
 LANGUAGES_ARR=$(echo $LANGUAGES | tr "," "\n")
 
 mkdir ~/.localize
-mkdir $GITHUB_WORKSPACE/$OUTPUTPATH
+mkdir -p $GITHUB_WORKSPACE/$OUTPUTPATH
 
 create_config() {
   echo "
@@ -37,10 +38,10 @@ echo "  - file: $GITHUB_WORKSPACE/$INPUTPATH/en.json" >> ~/.localize/config.yml
 restructure_files() {
   for lang in $LANGUAGES_ARR
     do
-      mkdir $GITHUB_WORKSPACE/$OUTPUTPATH/$lang
+      mkdir -p $GITHUB_WORKSPACE/$OUTPUTPATH/$lang
       mv $GITHUB_WORKSPACE/$OUTPUTPATH/$lang.json $GITHUB_WORKSPACE/$OUTPUTPATH/$lang/translations.json
     done
-    mkdir $GITHUB_WORKSPACE/$OUTPUTPATH/en
+    mkdir -p $GITHUB_WORKSPACE/$OUTPUTPATH/en
     cp $GITHUB_WORKSPACE/$OUTPUTPATH/en.json $GITHUB_WORKSPACE/$OUTPUTPATH/en/translations.json
 }
 

--- a/.github/actions/localize-push-pull/entrypoint.sh
+++ b/.github/actions/localize-push-pull/entrypoint.sh
@@ -52,7 +52,7 @@ elif [ "$ACTION" = "pull" ]; then
   create_config
   localize pull
   cp $GITHUB_WORKSPACE/$INPUTPATH/en.json $GITHUB_WORKSPACE/$OUTPUTPATH/en.json
-  if [ "$RESTRUCTURE" = true ]; then
+  if [ "$RESTRUCTURE" = "true" ]; then
     restructure_files
   fi
   exit 0

--- a/.github/actions/localize-push-pull/entrypoint.sh
+++ b/.github/actions/localize-push-pull/entrypoint.sh
@@ -52,7 +52,9 @@ if [ "$ACTION" = "push" ]; then
 elif [ "$ACTION" = "pull" ]; then
   create_config
   localize pull
-  cp -p $GITHUB_WORKSPACE/$INPUTPATH/en.json $GITHUB_WORKSPACE/$OUTPUTPATH/en.json
+  if [ "$INPUTPATH" != "$OUTPUTPATH" ]; then
+    cp -p $GITHUB_WORKSPACE/$INPUTPATH/en.json $GITHUB_WORKSPACE/$OUTPUTPATH/en.json
+  fi
   if [ "$RESTRUCTURE" = "true" ]; then
     restructure_files
   fi

--- a/.github/actions/localize-push-pull/entrypoint.sh
+++ b/.github/actions/localize-push-pull/entrypoint.sh
@@ -41,8 +41,8 @@ restructure_files() {
       mkdir -p $GITHUB_WORKSPACE/$OUTPUTPATH/$lang
       mv $GITHUB_WORKSPACE/$OUTPUTPATH/$lang.json $GITHUB_WORKSPACE/$OUTPUTPATH/$lang/translations.json
     done
-    mkdir -p $GITHUB_WORKSPACE/$OUTPUTPATH/en
-    cp -p $GITHUB_WORKSPACE/$OUTPUTPATH/en.json $GITHUB_WORKSPACE/$OUTPUTPATH/en/translations.json
+  mkdir -p $GITHUB_WORKSPACE/$OUTPUTPATH/en
+  cp -p $GITHUB_WORKSPACE/$OUTPUTPATH/en.json $GITHUB_WORKSPACE/$OUTPUTPATH/en/translations.json
 }
 
 if [ "$ACTION" = "push" ]; then

--- a/.github/actions/localize-push-pull/entrypoint.sh
+++ b/.github/actions/localize-push-pull/entrypoint.sh
@@ -42,7 +42,7 @@ restructure_files() {
       mv $GITHUB_WORKSPACE/$OUTPUTPATH/$lang.json $GITHUB_WORKSPACE/$OUTPUTPATH/$lang/translations.json
     done
     mkdir -p $GITHUB_WORKSPACE/$OUTPUTPATH/en
-    cp $GITHUB_WORKSPACE/$OUTPUTPATH/en.json $GITHUB_WORKSPACE/$OUTPUTPATH/en/translations.json
+    cp -p $GITHUB_WORKSPACE/$OUTPUTPATH/en.json $GITHUB_WORKSPACE/$OUTPUTPATH/en/translations.json
 }
 
 if [ "$ACTION" = "push" ]; then
@@ -52,7 +52,7 @@ if [ "$ACTION" = "push" ]; then
 elif [ "$ACTION" = "pull" ]; then
   create_config
   localize pull
-  cp $GITHUB_WORKSPACE/$INPUTPATH/en.json $GITHUB_WORKSPACE/$OUTPUTPATH/en.json
+  cp -p $GITHUB_WORKSPACE/$INPUTPATH/en.json $GITHUB_WORKSPACE/$OUTPUTPATH/en.json
   if [ "$RESTRUCTURE" = "true" ]; then
     restructure_files
   fi


### PR DESCRIPTION
We ran into a problem trying to [alphabetize locale keys](https://github.com/submittable/volunteerism-mvp-frontend/commit/e8c94997091f40d998e90c4d875005e34a70aef6) inside our own actions ([logs](https://github.com/submittable/volunteerism-mvp-frontend/actions/runs/8225708572/job/22491105743)), so the goal here is to avoid the permissions issue by executing the sort inside the same process (Docker image) that is manipulating the files in the first place.

The cleanups are mostly related to avoiding warning logs in the job output, e.g. `mkdir: cannot create directory ‘/github/workspace/public/locales’: File exists`, as well as addressing the string-ness of the input spec `default:`.

We will test this in our repo's actions before merging here.